### PR TITLE
Fix README doc for SIM111.

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ for x in iterable:
 return True
 
 # Good
-return all(check(x) for x in iterable)
+return all(not check(x) for x in iterable)
 ```
 
 ### SIM112


### PR DESCRIPTION
The warning message for SIM111 is correct, but the documented example for it isn't.

Example 2 in the closed Issue #15 should be edited too, since it's also linked from the documentation.

