### PR TITLE
BUG: Fix infinite recursion in SIM114

### DIFF
--- a/flake8_simplify.py
+++ b/flake8_simplify.py
@@ -1152,7 +1152,7 @@ def is_stmt_equal(a: ast.stmt, b: ast.stmt) -> bool:
         return False
     if isinstance(a, ast.AST):
         for k, v in vars(a).items():
-            if k in ("lineno", "col_offset", "ctx", "end_lineno", "parent"):
+            if k.startswith("_") or k in ("lineno", "col_offset", "ctx", "end_lineno", "parent"):
                 continue
             if not is_stmt_equal(v, getattr(b, k)):
                 return False


### PR DESCRIPTION
In case other flake8 plugins have inserted own fields in the AST, SIM114 can cause an infinite recursion.
Skip any fields starting with _ in the statement equality comparison to prevent this from happening.

This fixes https://github.com/MartinThoma/flake8-simplify/issues/66