### PR TITLE
Make SIM119 not trigger on complex operations in the constructor, and when async methods are present on a class.

### DIFF
--- a/flake8_simplify.py
+++ b/flake8_simplify.py
@@ -1099,14 +1099,16 @@ def _get_sim119(node: ast.ClassDef) -> List[Tuple[int, int, str]]:
         if isinstance(body_el, (ast.FunctionDef, ast.AsyncFunctionDef)):
             has_any_functions = True
             if body_el.name == "__init__":
-                # Ensure constructor only has pure assignments without any calculation.
+                # Ensure constructor only has pure assignments
+                # without any calculation.
                 has_complex_statements = False
                 for el in body_el.body:
                     if not isinstance(el, ast.Assign):
                         has_complex_statements = True
                         break
                     else:
-                        # It is an assignment, but we only allow `self.attribute = name`.
+                        # It is an assignment, but we only allow
+                        # `self.attribute = name`.
                         if any(
                             [
                                 not isinstance(target, ast.Attribute)

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -488,7 +488,6 @@ class FooBar:
 def test_sim119_ignored_dunder_methods():
     """
     Dunder methods do not make a class not be a dataclass candidate.
-    
     Examples for dunder (double underscore) methods are:
       * __str__
       * __eq__

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -486,7 +486,14 @@ class FooBar:
 
 
 def test_sim119_ignored_dunder_methods():
-    """Dunder methods like __str__ do not make a class not be a dataclass candidate."""
+    """
+    Dunder methods do not make a class not be a dataclass candidate.
+    
+    Examples for dunder (double underscore) methods are:
+      * __str__
+      * __eq__
+      * __hash__
+    """
     results = _results(
         """
 class FooBar:

--- a/tests/test_simplify.py
+++ b/tests/test_simplify.py
@@ -480,12 +480,51 @@ class FooBar:
     def __init__(self, a, b):
         self.a = a
         self.b = b
+"""
+    )
+    assert results == {"2:0 SIM119 Use a dataclass for 'class FooBar'"}
+
+
+def test_sim119_ignored_dunder_methods():
+    """Dunder methods like __str__ do not make a class not be a dataclass candidate."""
+    results = _results(
+        """
+class FooBar:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
 
     def __str__(self):
         return "FooBar"
 """
     )
     assert results == {"2:0 SIM119 Use a dataclass for 'class FooBar'"}
+
+
+def test_sim119_async():
+    results = _results(
+        """
+class FooBar:
+    def __init__(self, a, b):
+        self.a = a
+        self.b = b
+
+    async def foo(self):
+        return "FooBar"
+"""
+    )
+    assert results == set()
+
+
+def test_sim119_constructor_processing():
+    results = _results(
+        """
+class FooBar:
+    def __init__(self, a):
+        self.a = a + 5
+"""
+    )
+    assert results == set()
 
 
 def test_sim119_pydantic():


### PR DESCRIPTION
Closes issue #63.