### PR TITLE
SIM116: Fix false-positive

### DIFF
--- a/flake8_simplify/rules/ast_if.py
+++ b/flake8_simplify/rules/ast_if.py
@@ -275,6 +275,11 @@ def get_sim116(node: ast.If) -> List[Tuple[int, int, str]]:
             and len(child.orelse) <= 1
         ):
             return errors
+        return_call = child.body[0]
+        assert isinstance(return_call, ast.Return), "hint for mypy"
+        if isinstance(return_call.value, ast.Call):
+            # See https://github.com/MartinThoma/flake8-simplify/issues/113
+            return errors
         key: Any
         if isinstance(child.test.comparators[0], ast.Str):
             key = child.test.comparators[0].s

--- a/tests/test_100_rules.py
+++ b/tests/test_100_rules.py
@@ -430,6 +430,21 @@ else:
     }
 
 
+def test_sim116_false_positive():
+    ret = _results(
+        """if a == "foo":
+    return "bar"
+elif a == "bar":
+    return baz()
+elif a == "boo":
+    return "ooh"
+else:
+    return 42"""
+    )
+    for el in ret:
+        assert "SIM116" not in el
+
+
 def test_sim117():
     ret = _results(
         """with A() as a:


### PR DESCRIPTION
When a function is called, we cannot simply convert the if-else
block to a dictionary.

Closes #113