### PR TITLE
SIM104: Remove false-positives in case the loop is not a direct child of an async function

### DIFF
--- a/flake8_simplify/rules/ast_for.py
+++ b/flake8_simplify/rules/ast_for.py
@@ -49,9 +49,12 @@ def get_sim104(node: ast.For) -> List[Tuple[int, int, str]]:
     ):
         return errors
 
-    parent = node.parent
-    while parent and not isinstance(parent, ast.AsyncFunctionDef):
-        parent = parent.parent
+    parent = getattr(node, "parent", None)
+    while (parent
+           and getattr(parent, "parent", None)
+           and parent.parent is not parent
+           and not isinstance(parent, ast.AsyncFunctionDef)):
+        parent = getattr(parent, "parent", None)
 
     if isinstance(parent, ast.AsyncFunctionDef):  # type: ignore
         return errors

--- a/flake8_simplify/rules/ast_for.py
+++ b/flake8_simplify/rules/ast_for.py
@@ -48,7 +48,12 @@ def get_sim104(node: ast.For) -> List[Tuple[int, int, str]]:
         or node.orelse != []
     ):
         return errors
-    if isinstance(node.parent, ast.AsyncFunctionDef):  # type: ignore
+
+    parent = node.parent
+    while parent and not isinstance(parent, ast.AsyncFunctionDef):
+        parent = parent.parent
+
+    if isinstance(parent, ast.AsyncFunctionDef):  # type: ignore
         return errors
     iterable = to_source(node.iter)
     errors.append(

--- a/flake8_simplify/rules/ast_for.py
+++ b/flake8_simplify/rules/ast_for.py
@@ -51,7 +51,7 @@ def get_sim104(node: ast.For) -> List[Tuple[int, int, str]]:
 
     parent = getattr(node, "parent", None)
     while (parent
-           and getattr(parent, "parent", None)
+           and hasattr(parent, "parent")
            and parent.parent is not parent
            and not isinstance(parent, ast.AsyncFunctionDef)):
         parent = getattr(parent, "parent", None)

--- a/tests/test_100_rules.py
+++ b/tests/test_100_rules.py
@@ -99,6 +99,17 @@ def test_s104_async_generator_false_positive():
         assert "SIM104" not in el
 
 
+def test_s104_async_generator_false_positive_2():
+    ret = _results(
+        """async def items():
+    with open('/etc/passwd') as f:
+        for line in f:
+            yield line"""
+    )
+    for el in ret:
+        assert "SIM104" not in el
+
+
 def test_sim105():
     ret = _results(
         """try:


### PR DESCRIPTION
Not all for loops within a function body is a direct child of the function body

Closes #146 