### PR TITLE
ENH: Add `dict.get(key, None)` → `dict.get(key)` as SIM910

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ Current experimental rules:
 * [`SIM907`](https://github.com/MartinThoma/flake8-simplify/issues/64): Use Optional[Type] instead of Union[Type, None] ([example](#SIM907))
 * [`SIM908`](https://github.com/MartinThoma/flake8-simplify/issues/50): Use dict.get(key) ([example](#SIM908))
 * [`SIM909`](https://github.com/MartinThoma/flake8-simplify/issues/114): Avoid reflexive assignments ([example](#SIM909))
+* [`SIM910`](https://github.com/MartinThoma/flake8-simplify/issues/171): Avoid to use `dict.get(key, None)` ([example](#SIM910))
 
 ## Disabling Rules
 
@@ -613,4 +614,14 @@ foo = foo = 42
 
 # Good
 foo = 42
+```
+
+### SIM910
+
+```python
+# Bad
+dict.get(key, None)
+
+# Good
+dict.get(key)
 ```

--- a/flake8_simplify/__init__.py
+++ b/flake8_simplify/__init__.py
@@ -19,6 +19,7 @@ from flake8_simplify.rules.ast_call import (
     get_sim901,
     get_sim905,
     get_sim906,
+    get_sim910,
 )
 from flake8_simplify.rules.ast_classdef import get_sim120
 from flake8_simplify.rules.ast_compare import get_sim118, get_sim300
@@ -74,6 +75,7 @@ class Visitor(ast.NodeVisitor):
         self.errors += get_sim901(node)
         self.errors += get_sim905(node)
         self.errors += get_sim906(node)
+        self.errors += get_sim910(Call(node))
         self.generic_visit(node)
 
     def visit_With(self, node: ast.With) -> Any:

--- a/flake8_simplify/rules/ast_call.py
+++ b/flake8_simplify/rules/ast_call.py
@@ -5,6 +5,7 @@ import logging
 from typing import List, Tuple
 
 # First party
+from flake8_simplify.constants import BOOL_CONST_TYPES
 from flake8_simplify.utils import Call, to_source
 
 logger = logging.getLogger(__name__)
@@ -215,7 +216,7 @@ def get_sim910(node: Call) -> List[Tuple[int, int, str]]:
     # check the argument value
     if not (
         len(node.args) == 2
-        and isinstance(node.args[1], ast.Constant)
+        and isinstance(node.args[1], BOOL_CONST_TYPES)
         and node.args[1].value is None
     ):
         return errors

--- a/tests/test_900_rules.py
+++ b/tests/test_900_rules.py
@@ -181,3 +181,26 @@ def test_sim909_false_positives(s):
     results = _results(s)
     for result in results:
         assert "SIM909" not in result
+
+
+@pytest.mark.parametrize(
+    ("s", "msg"),
+    (
+        (
+            "d.get(key, None)",
+            "1:0 SIM910 Use 'd.get(key)' instead of 'd.get(key, None)'",
+        ),
+        (
+            "d.get('key', None)",
+            "1:0 SIM910 Use 'd.get(\"key\")' instead of 'd.get('key', None)'",
+        ),
+        (
+            "d.get(key)",
+            None,
+        ),
+    ),
+)
+def test_sim910(s, msg):
+    expected = {msg} if msg is not None else set()
+    results = _results(s)
+    assert results == expected


### PR DESCRIPTION
close #171 

This PR implements the rules of `SIM910`.
This rule detects `dict.get(key, None)`.

ref:
https://docs.python.org/3/library/stdtypes.html?highlight=dict#dict.get