### PR TITLE
SIM911: Avoid using `zip(dict.keys(), dict.values())`

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Simplifying usage of dictionaries:
 
 * [`SIM401`](https://github.com/MartinThoma/flake8-simplify/issues/72): Use 'a_dict.get(key, "default_value")' instead of an if-block ([example](#SIM401))
 * [`SIM118`](https://github.com/MartinThoma/flake8-simplify/issues/40): Use 'key in dict' instead of 'key in dict.keys()' ([example](#SIM118))
+* `SIM119` Reserved for [SIM911](#sim911) once it's stable
 
 General Code Style:
 
@@ -106,6 +107,7 @@ Current experimental rules:
 * [`SIM908`](https://github.com/MartinThoma/flake8-simplify/issues/50): Use dict.get(key) ([example](#SIM908))
 * [`SIM909`](https://github.com/MartinThoma/flake8-simplify/issues/114): Avoid reflexive assignments ([example](#SIM909))
 * [`SIM910`](https://github.com/MartinThoma/flake8-simplify/issues/171): Avoid to use `dict.get(key, None)` ([example](#SIM910))
+* [`SIM911`](https://github.com/MartinThoma/flake8-simplify/issues/161): Avoid using `zip(dict.keys(), dict.values())` ([example](#SIM911))
 
 ## Disabling Rules
 

--- a/flake8_simplify/__init__.py
+++ b/flake8_simplify/__init__.py
@@ -20,6 +20,7 @@ from flake8_simplify.rules.ast_call import (
     get_sim905,
     get_sim906,
     get_sim910,
+    get_sim911,
 )
 from flake8_simplify.rules.ast_classdef import get_sim120
 from flake8_simplify.rules.ast_compare import get_sim118, get_sim300
@@ -76,6 +77,7 @@ class Visitor(ast.NodeVisitor):
         self.errors += get_sim905(node)
         self.errors += get_sim906(node)
         self.errors += get_sim910(Call(node))
+        self.errors += get_sim911(node)
         self.generic_visit(node)
 
     def visit_With(self, node: ast.With) -> Any:

--- a/tests/test_900_rules.py
+++ b/tests/test_900_rules.py
@@ -236,5 +236,5 @@ def test_sim910(s, msg):
         ),
     ),
 )
-def test_sim911(s: str, expected: Optional[Set]):
+def test_sim911(s, expected):
     assert _results(s) == (expected or set())

--- a/tests/test_900_rules.py
+++ b/tests/test_900_rules.py
@@ -1,3 +1,6 @@
+# Core Library
+from typing import Optional, Set
+
 # Third party
 import pytest
 
@@ -204,3 +207,34 @@ def test_sim910(s, msg):
     expected = {msg} if msg is not None else set()
     results = _results(s)
     assert results == expected
+
+
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        (
+            "zip(d.keys(), d.values())",
+            {
+                "1:0 SIM911 Use 'd.items()' instead of 'zip(d.keys(), d.values())'"
+            },
+        ),
+        (
+            "zip(d.keys(), d.keys())",
+            None,
+        ),
+        (
+            "zip(d1.keys(), d2.values())",
+            None,
+        ),
+        (
+            "zip(d1.keys(), values)",
+            None,
+        ),
+        (
+            "zip(keys, values)",
+            None,
+        ),
+    ),
+)
+def test_sim911(s: str, expected: Optional[Set]):
+    assert _results(s) == (expected or set())

--- a/tests/test_900_rules.py
+++ b/tests/test_900_rules.py
@@ -1,6 +1,3 @@
-# Core Library
-from typing import Optional, Set
-
 # Third party
 import pytest
 


### PR DESCRIPTION
closes: https://github.com/MartinThoma/flake8-simplify/issues/161