### PR TITLE
Add support for Python 3.12 and 3.13

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: [3.8]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -3,11 +3,7 @@
 
 name: Unit Tests
 
-on:
-  push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+on: [push, pull_request, workflow_dispatch]
 
 jobs:
   build:
@@ -15,10 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.8, 3.9, "3.10", 3.11, 3.12]
+        python-version: [3.8, 3.9, "3.10", 3.11, 3.12, 3.13]
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Install with `pip`:
 pip install flake8-simplify
 ```
 
-Python 3.8 to 3.11 are supported.
+Python 3.8 to 3.13 are supported.
 
 
 ## Usage

--- a/flake8_simplify/__init__.py
+++ b/flake8_simplify/__init__.py
@@ -1,7 +1,6 @@
 # Core Library
 import ast
 import logging
-import sys
 from typing import Any, Generator, List, Tuple, Type
 
 # First party
@@ -54,12 +53,8 @@ from flake8_simplify.utils import Assign, Call, For, If, UnaryOp
 logger = logging.getLogger(__name__)
 
 
-if sys.version_info < (3, 8):  # pragma: no cover (<PY38)
-    # Third party
-    import importlib_metadata
-else:  # pragma: no cover (PY38+)
-    # Core Library
-    import importlib.metadata as importlib_metadata
+# Core Library
+import importlib.metadata as importlib_metadata
 
 
 class Visitor(ast.NodeVisitor):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,8 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Software Development",
     "Framework :: Flake8",
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,py38,py39,py310,py311
+envlist = lint,py{38,39,310,311,312,313}
 
 [testenv]
 deps =


### PR DESCRIPTION
Also remove dependency on `importlib_metadata`, it'll never be used as 3.8 is the lowest version supported.